### PR TITLE
Update for 1.0.0 stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
             "email": "hello@humanmade.com"
         }
     ],
-    "minimum-stability": "RC",
-    "prefer-stable": true,
+    "minimum-stability": "stable",
     "extra": {
         "installer-paths": {
             "content/mu-plugins/{$name}/": [

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "A base Altis project to get started with",
     "type": "project",
     "require": {
-        "altis/altis": "1.0.0-rc3"
+        "altis/altis": "^1.0.0"
     },
     "require-dev": {
-        "altis/local-chassis": "1.0.0-rc3",
-        "altis/local-server": "1.0.0-rc3"
+        "altis/local-chassis": "^1.0.0",
+        "altis/local-server": "^1.0.0"
     },
     "authors": [
         {
@@ -16,6 +16,7 @@
         }
     ],
     "minimum-stability": "RC",
+    "prefer-stable": true,
     "extra": {
         "installer-paths": {
             "content/mu-plugins/{$name}/": [


### PR DESCRIPTION
I'm not 100% sure if leaving the minimum stability and adding `prefer-stable` is correct but it seems opting in to a package at `1.4.0@RC` for example will fail without this.