### PR TITLE
Override PHP platform version to ease install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
                 "type:wordpress-theme"
             ]
         }
+    },
+    "config": {
+        "platform": {
+            "php": "7.2"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "config": {
         "platform": {
-            "php": "7.2"
+            "php": "7.2",
+            "ext-mbstring": "7.2.30"
         }
     }
 }


### PR DESCRIPTION
If you're running a different version of PHP locally to the server, you can end up in a situation where package versions differ, or Altis is just uninstallable locally. For example, without mbstring installed:

```
$ composer create-project altis/skeleton my-project
Creating a "altis/skeleton" project at "./my-project"
Installing altis/skeleton (3.0.0)
  - Installing altis/skeleton (3.0.0): Downloading (100%)
Created project in /home/rmccue/my-project
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - phpunit/phpunit 7.5.9 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
    - phpunit/phpunit 7.5.8 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
...
```

Adding a config section helps with this. May also need to set some more versions!