### PR TITLE
Increase config platform version number to 7.2.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2",
+            "php": "7.2.34",
             "ext-mbstring": "7.2.30"
         }
     }


### PR DESCRIPTION
The minimum requirement now for the nightly build is 7.2.5 but the PHP container is on 7.2.34.