### PR TITLE
Add necessary Composer plugins to allow-plugins list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,15 @@
         "platform": {
             "php": "7.4.13",
             "ext-mbstring": "7.4.13"
+        },
+        "allow-plugins": {
+            "composer/installers": true,
+            "johnpbloch/wordpress-core-installer": true,
+            "altis/cms-installer": true,
+            "altis/dev-tools-command": true,
+            "altis/core": true,
+            "altis/local-chassis": true,
+            "altis/local-server": true
         }
     }
 }


### PR DESCRIPTION
[Composer 2.2](https://blog.packagist.com/composer-2-2/) (released in December 2021) warns on every composer command when unknown plugins are detected. This change to the skeleton composer.json file permits all expected Altis dependencies to run their composer plugins.