### PR TITLE
Release 12.0.0-beta.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,10 @@
     "description": "A base Altis project to get started with",
     "type": "project",
     "require": {
-        "altis/altis": "dev-master"
+        "altis/altis": "^12.0.0@beta"
     },
     "require-dev": {
-        "altis/local-chassis": "dev-master",
-        "altis/local-server": "dev-master"
+        "altis/local-server": "^12.0.0@beta"
     },
     "authors": [
         {
@@ -15,7 +14,7 @@
             "email": "hello@humanmade.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "beta",
     "extra": {
         "installer-paths": {
             "content/mu-plugins/{$name}/": [


### PR DESCRIPTION
Points to the 12.0.0 beta release of the altis and local-server packages, updates minimum stability, removes altis/local-chassis as it is being deprecated.