### PR TITLE
Remove minimum-stability: dev from composer.json v19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
             "email": "hello@humanmade.com"
         }
     ],
-    "minimum-stability": "dev",
     "extra": {
         "installer-paths": {
             "content/mu-plugins/{$name}/": [


### PR DESCRIPTION
  Remove minimum-stability: dev from composer.json
Resolves an upgrade problem trying to pull a version of Codeception that is too new.