### PR TITLE
Ignore unused aws/aws-sdk-php advisories on v23-branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,12 @@
             "composer/installers": true,
             "johnpbloch/wordpress-core-installer": true,
             "altis/*": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-4t1p-xpk2-nsss": "CloudFront Policy Document Injection in Aws\\CloudFront\\Signer. Altis does not use CloudFront URL/cookie signing - only CloudFrontClient::createInvalidation is called for cache purging.",
+                "PKSA-dxyf-6n16-t87m": "S3 Encryption Client Key Commitment in Aws\\S3\\Crypto\\S3EncryptionClient*. Altis does not use S3 client-side encryption - humanmade/s3-uploads uses only the plain S3Client."
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `config.audit.ignore` entries for `PKSA-4t1p-xpk2-nsss` and `PKSA-dxyf-6n16-t87m` so `composer install` succeeds on the pinned `aws/aws-sdk-php: 3.351.7` that altis/core v23-branch requires.
- Both advisories cover AWS SDK features that Altis does not use.

## Why this is needed
`altis/core@v23-branch` pins `aws/aws-sdk-php` at 3.351.7 to avoid the SignatureDoesNotMatch local-upload regression introduced in 3.351.8+ (altis-core#1293, product-dev#1831). 3.351.7 is affected by two advisories that composer now blocks installs against:

| Advisory | Affects | Altis usage |
|---|---|---|
| `PKSA-4t1p-xpk2-nsss` (CloudFront Policy Document Injection) | `Aws\CloudFront\Signer::getSignedUrl` / `getSignedCookie` | None. Only `CloudFrontClient::createInvalidation` is called (cache purging in altis/cloud, admin-supplied path patterns). Zero call sites for the affected signer. |
| `PKSA-dxyf-6n16-t87m` (S3 Encryption Key Commitment) | `Aws\S3\Crypto\S3EncryptionClient*` with Instruction File EDK strategy | None. Plain `Aws\S3\S3Client` only via `humanmade/s3-uploads`. Zero call sites for `S3EncryptionClient*` / `InstructionFileMetadataStrategy` / `MaterialsProvider`. Server-side encryption only. |

Audit verified by grepping `vendor/altis/`, `vendor/humanmade/`, `extra-packages/`, and `packages/` — no occurrences.

## Companion changes
- `altis/core@v24-branch`: re-pin `aws/aws-sdk-php` from 3.379.9 back to 3.351.7 (separate PR).
- `altis/core@v25-branch`: re-pin `aws/aws-sdk-php` from 3.379.9 back to 3.351.7 (separate PR).
- `altis/core@v23-branch`: already at 3.351.7; no change needed.

## Test plan
- [ ] After this lands, trigger the product-dev nightly against Altis 23 and confirm `composer install` no longer fails with "affected by security advisories".

🤖 Generated with [Claude Code](https://claude.com/claude-code)