### PR TITLE
Update default PHP version to 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     },
     "config": {
         "platform": {
-            "php": "8.3",
-            "ext-mbstring": "8.3"
+            "php": "8.4",
+            "ext-mbstring": "8.4"
         },
         "allow-plugins": {
             "composer/installers": true,


### PR DESCRIPTION
Promotes PHP 8.4 to the default; minimum stays 8.2.